### PR TITLE
Use Action.Type to Dispatcher.register

### DIFF
--- a/DemoApp/TodoAction.swift
+++ b/DemoApp/TodoAction.swift
@@ -15,7 +15,7 @@ class TodoAction {
         typealias Payload = [Todo]
         func invoke() {
             let todos = [Todo(title: "List ToDo 1"), Todo(title: "List ToDo 2"), Todo(title: "List ToDo 3")]
-            Dispatcher.dispatch(self, result: Result(value: todos))
+            Dispatcher.dispatch(self.dynamicType, result: Result(value: todos))
         }
     }
 
@@ -30,7 +30,7 @@ class TodoAction {
         }
         
         func invoke() {
-            Dispatcher.dispatch(self, result: Result(value: Todo(title: self.title)))
+            Dispatcher.dispatch(self.dynamicType, result: Result(value: Todo(title: self.title)))
         }
     }
 }

--- a/DemoApp/TodoStore.swift
+++ b/DemoApp/TodoStore.swift
@@ -28,7 +28,7 @@ class TodoStore : Store {
     }
 
     init() {
-        Dispatcher.register(TodoAction.List()) { (result) -> Void in
+        Dispatcher.register(TodoAction.List.self) { (result) -> Void in
             switch result {
             case .Success(let box):
                 self.todos = box.value
@@ -38,7 +38,7 @@ class TodoStore : Store {
             }
         }
 
-        Dispatcher.register(TodoAction.Create()) { (result) -> Void in
+        Dispatcher.register(TodoAction.Create.self) { (result) -> Void in
             switch result {
             case .Success(let box):
                 self.todos.insert(box.value, atIndex: 0)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Circle CI](https://img.shields.io/circleci/project/yonekawa/SwiftFlux/master.svg?style=flat)](https://circleci.com/gh/yonekawa/SwiftFlux)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
-SwiftFlux is an implementation of [Facebook's Flux architecure](https://facebook.github.io/flux/) for Swift. 
+SwiftFlux is an implementation of [Facebook's Flux architecure](https://facebook.github.io/flux/) for Swift.
 It provides concept of "one-way data flow" with **type-safe** modules by Swift language.
 
 - Type of an action payload is inferred from the type of its action.
@@ -67,7 +67,7 @@ class TodoStore : Store {
     }
 
     init() {
-        Dispatcher.register(TodoAction.List()) { (result) -> Void in
+        Dispatcher.register(TodoAction.List.self) { (result) -> Void in
             switch result {
             case .Success(let box):
                 self.todo = box.value

--- a/SwiftFlux/Action.swift
+++ b/SwiftFlux/Action.swift
@@ -11,5 +11,4 @@ import Result
 
 public protocol Action {
     typealias Payload
-    func invoke() -> Void
 }

--- a/SwiftFlux/Dispatcher.swift
+++ b/SwiftFlux/Dispatcher.swift
@@ -14,6 +14,7 @@ public class Dispatcher {
     private var callbacks: Dictionary<String, AnyObject> = [:]
     private var _isDispatching = false
     private var lastDispatchIdentifier = 0
+    private init() {}
 }
 
 extension Dispatcher {

--- a/SwiftFlux/EventEmitter.swift
+++ b/SwiftFlux/EventEmitter.swift
@@ -11,31 +11,30 @@ import Foundation
 public class EventEmitter {
     private static let instance = EventEmitter()
     private var listenes: Dictionary<String, AnyObject> = [:]
-    private var lastId = 0
-    private init() {}
+    private var lastListenerIdentifier = 0
 }
 
 extension EventEmitter {
     public class func listen<T: Store>(store: T, event: T.Event, handler: () -> Void) -> String {
         return self.instance.listen(store, event: event, handler: handler)
     }
-    
+
     public class func emit<T: Store>(store: T, event: T.Event) {
         self.instance.emit(store, event: event)
     }
-    
-    public class func unlisten(id: String) {
-        self.instance.unlisten(id)
+
+    public class func unlisten(identifier: String) {
+        self.instance.unlisten(identifier)
     }
 }
 
 extension EventEmitter {
     private func listen<T: Store>(store: T, event: T.Event, handler: () -> Void) -> String {
-        let nextId = "EVENT_LISTENER_\(++lastId)"
-        self.listenes[nextId] = EventListener<T>(store: store, event: event, handler: handler)
-        return nextId
+        let nextListenerIdentifier = "EVENT_LISTENER_\(++lastListenerIdentifier)"
+        self.listenes[nextListenerIdentifier] = EventListener<T>(store: store, event: event, handler: handler)
+        return nextListenerIdentifier
     }
-    
+
     private func emit<T: Store>(store: T, event: T.Event) {
         for (key, value) in self.listenes {
             if let listener = value as? EventListener<T> {
@@ -45,9 +44,9 @@ extension EventEmitter {
             }
         }
     }
-    
-    private func unlisten(id: String) {
-        self.listenes.removeValueForKey(id)
+
+    private func unlisten(identifier: String) {
+        self.listenes.removeValueForKey(identifier)
     }
 }
 

--- a/SwiftFlux/EventEmitter.swift
+++ b/SwiftFlux/EventEmitter.swift
@@ -12,6 +12,7 @@ public class EventEmitter {
     private static let instance = EventEmitter()
     private var listenes: Dictionary<String, AnyObject> = [:]
     private var lastListenerIdentifier = 0
+    private init() {}
 }
 
 extension EventEmitter {

--- a/SwiftFlux/Info.plist
+++ b/SwiftFlux/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.1</string>
+	<string>0.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/SwiftFlux/Store.swift
+++ b/SwiftFlux/Store.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 public protocol Store {
-    typealias Event: Hashable
+    typealias Event: Equatable
 }

--- a/SwiftFluxTests/DispatcherSpec.swift
+++ b/SwiftFluxTests/DispatcherSpec.swift
@@ -33,7 +33,7 @@ class DispatcherSpec: QuickSpec {
                 fails = []
                 callbacks = []
 
-                let id1 = Dispatcher.register(TestAction()) { (result) in
+                let id1 = Dispatcher.register(TestAction.self) { (result) in
                     switch result {
                     case .Success(let box):
                         results.append("\(box.value.name)1")
@@ -41,7 +41,7 @@ class DispatcherSpec: QuickSpec {
                         fails.append("fail")
                     }
                 }
-                let id2 = Dispatcher.register(TestAction()) { (result) in
+                let id2 = Dispatcher.register(TestAction.self) { (result) in
                     switch result {
                     case .Success(let box):
                         results.append("\(box.value.name)2")
@@ -61,7 +61,7 @@ class DispatcherSpec: QuickSpec {
             
             context("when action succeeded") {
                 it("should dispatch to registered callback handlers") {
-                    Dispatcher.dispatch(TestAction(), result: Result(value: TestModel(name: "test")))
+                    Dispatcher.dispatch(TestAction.self, result: Result(value: TestModel(name: "test")))
                     expect(results.count).to(equal(2))
                     expect(fails.isEmpty).to(beTruthy())
                     expect(results).to(contain("test1", "test2"))
@@ -70,7 +70,7 @@ class DispatcherSpec: QuickSpec {
             
             context("when action failed") {
                 it("should dispatch to registered callback handlers") {
-                    Dispatcher.dispatch(TestAction(), result: Result(error: NSError()))
+                    Dispatcher.dispatch(TestAction.self, result: Result(error: NSError()))
                     expect(fails.count).to(equal(2))
                     expect(results.isEmpty).to(beTruthy())
                 }

--- a/SwiftFluxTests/Info.plist
+++ b/SwiftFluxTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>
 </plist>


### PR DESCRIPTION
Change interface `Dispatcher.register` to avoid action instance.
For example `Dispatcher.register(Action.Type.self)`
