### PR TITLE
Update Result for use APIKit v1.0.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "antitypical/Result" "0.5"
+github "antitypical/Result" "0.6.0-beta.3"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "robrix/Box" "2.0"
 github "Quick/Nimble" "v2.0.0"
 github "Quick/Quick" "v0.6.0"
-github "antitypical/Result" "0.5"
+github "antitypical/Result" "0.6.0-beta.3"


### PR DESCRIPTION
SwiftFlux conflicts antitypical/Result version to APIKit 1.0.0.
Update version to same as APIKit
