### PR TITLE
Simplify ReduceStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ Reducer should be pure and have no side-effects.
 
 ```swift
 class CalculateStore: ReduceStore<Int> {
-    override init() {
-        super.init()
+    init() {
+        super.init(initialState: 0)
 
         self.reduce(CalculateActions.Plus.self) { (state, result) -> Int in
             switch result {
@@ -264,10 +264,6 @@ class CalculateStore: ReduceStore<Int> {
             default: return state
             }
         }
-    }
-
-    override var initialState: Int {
-        return 0
     }
 }
 ```

--- a/SwiftFlux/Dispatcher.swift
+++ b/SwiftFlux/Dispatcher.swift
@@ -18,7 +18,6 @@ public protocol Dispatcher {
 
 public class DefaultDispatcher: Dispatcher {
     private var callbacks: Dictionary<String, AnyObject> = [:]
-    private var _isDispatching = false
     private var lastDispatchIdentifier = 0
 
     public init() {}
@@ -63,22 +62,15 @@ public class DefaultDispatcher: Dispatcher {
         for identifier in self.callbacks.keys {
             self.invokeCallback(identifier, type: type, result: result)
         }
-        self.finishDispatching()
 
         objc_sync_exit(self)
     }
 
     private func startDispatching<T: Action>(type: T.Type) {
-        self._isDispatching = true
-
         for (identifier, _) in self.callbacks {
             guard let callback = self.callbacks[identifier] as? DispatchCallback<T> else { continue }
             callback.status = DispatchStatus.Waiting
         }
-    }
-
-    private func finishDispatching() {
-        self._isDispatching = false
     }
 
     private func invokeCallback<T: Action>(identifier: String, type: T.Type, result: Result<T.Payload, T.Error>) {

--- a/SwiftFlux/Utils/ReduceStore.swift
+++ b/SwiftFlux/Utils/ReduceStore.swift
@@ -9,15 +9,15 @@
 import Result
 
 public class ReduceStore<T: Equatable>: StoreBase {
-    override public init() {}
+    public init(initialState: T) {
+        self.initialState = initialState
+        super.init()
+    }
 
+    private var initialState: T
     private var internalState: T?
     public var state: T {
         return internalState ?? initialState
-    }
-
-    public var initialState: T {
-        fatalError("\(self.dynamicType) has not overridden ReduceStore.initialState, which is required")
     }
 
     public func reduce<A: Action>(type: A.Type, reducer: (T, Result<A.Payload, A.Error>) -> T) -> String {

--- a/SwiftFluxTests/Utils/ReduceStoreSpec.swift
+++ b/SwiftFluxTests/Utils/ReduceStoreSpec.swift
@@ -30,8 +30,8 @@ class ReduceStoreSpec: QuickSpec {
     }
 
     class CalculateStore: ReduceStore<Int> {
-        override init() {
-            super.init()
+        init() {
+            super.init(initialState: 0)
 
             self.reduce(CalculateActions.Plus.self) { (state, result) -> Int in
                 switch result {
@@ -46,10 +46,6 @@ class ReduceStoreSpec: QuickSpec {
                 default: return state
                 }
             }
-        }
-
-        override var initialState: Int {
-            return 0
         }
     }
 


### PR DESCRIPTION
Use constructor instead of override func for `initialState`
