### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Travis CI](https://travis-ci.org/yonekawa/SwiftFlux.svg?branch=master)](https://travis-ci.org/yonekawa/SwiftFlux)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
-[![Cocoapods](https://img.shields.io/cocoapods/v/SwiftFlux.svg)](https://cocoapods.org/pods/SwiftFlux)
+[![CocoaPods](https://img.shields.io/cocoapods/v/SwiftFlux.svg)](https://cocoapods.org/pods/SwiftFlux)
 
 SwiftFlux is an implementation of [Facebook's Flux architecure](https://facebook.github.io/flux/) for Swift.  
 It provides concept of "one-way data flow" with **type-safe** modules by Swift language.
@@ -26,7 +26,7 @@ It provides concept of "one-way data flow" with **type-safe** modules by Swift l
 - Run `carthage update`.
 - Link your app with `SwiftFlux.framework`, `Result.framework`, in Carthage/Build
 
-#### [Cocoapods](https://cocoapods.org/)
+#### [CocoaPods](https://cocoapods.org/)
 
 - Insert `pod "SwiftFlux"` to your Podfile:
 - Run `pod install`.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
